### PR TITLE
Remove useless mem::replace

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -30,7 +30,6 @@ impl Broker {
         let id = TypeId::of::<M>();
         let subs = self.sub_map.get_mut(&id)?;
         trace!("Broker: Found subscription list for {:?}.", id);
-        let mut subs = mem::replace(subs, Vec::new());
         let subs = subs.drain(..)
             .filter_map(|(id, s)| {
                 if let Ok(rec) = s.downcast::<Recipient<M>>() {


### PR DESCRIPTION
Hi,
thanks alot for writing actix-broker, I think it's awesome. 

Just one thing, when looking over the code I ran into this strange line using mem::replace on a variable. As far as I can tell, the operation is a no-op. I tested actix-broker without it, and everything seems to work just fine.

If you would happen to agree that it's there by mistake, here's a pull request to remove it.

Also, it's just my opinion, but I would find it amazing if people would take a habit of commenting code that's not obvious. In this case there might be a side-effect of calling mem::replace which you wanted, but it's not obvious at all for anyone reading the code what this is supposed to do. 