### PR TITLE
split system and per-arbiter brokers

### DIFF
--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -3,7 +3,7 @@ extern crate actix_broker;
 extern crate actix_web;
 
 use actix::prelude::*;
-use actix_broker::{Broker, BrokerSubscribe};
+use actix_broker::{Broker, BrokerSubscribe, SystemBroker};
 use actix_web::{web, App, Error, HttpRequest, HttpResponse, HttpServer};
 
 #[derive(Clone, Debug, Message)]
@@ -15,7 +15,7 @@ impl Actor for TestActor {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        self.subscribe_async::<Hello>(ctx);
+        self.subscribe_async::<SystemBroker, Hello>(ctx);
     }
 }
 
@@ -28,7 +28,7 @@ impl Handler<Hello> for TestActor {
 }
 
 fn index(_req: HttpRequest) -> Result<HttpResponse, Error> {
-    Broker::issue_async(Hello);
+    Broker::<SystemBroker>::issue_async(Hello);
     Ok(HttpResponse::Ok()
         .content_type("text/plain")
         .body("Welcome!"))

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,18 +2,20 @@ extern crate actix;
 extern crate actix_broker;
 
 use actix::prelude::*;
-use actix_broker::{BrokerIssue, BrokerSubscribe};
+use actix_broker::{BrokerIssue, BrokerSubscribe, SystemBroker};
 
 struct ActorOne;
 struct ActorTwo;
 struct ActorThree;
 
+type BrokerType = SystemBroker;
+
 impl Actor for ActorOne {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        self.subscribe_sync::<MessageTwo>(ctx);
-        self.issue_async(MessageOne("hello".to_string()));
+        self.subscribe_sync::<BrokerType, MessageTwo>(ctx);
+        self.issue_async::<BrokerType, _>(MessageOne("hello".to_string()));
     }
 }
 
@@ -29,7 +31,7 @@ impl Actor for ActorTwo {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        self.subscribe_async::<MessageOne>(ctx);
+        self.subscribe_async::<BrokerType, MessageOne>(ctx);
     }
 }
 
@@ -38,7 +40,7 @@ impl Handler<MessageOne> for ActorTwo {
 
     fn handle(&mut self, msg: MessageOne, _ctx: &mut Self::Context) {
         println!("ActorTwo Received: {:?}", msg);
-        self.issue_async(MessageTwo(0));
+        self.issue_async::<BrokerType, _>(MessageTwo(0));
     }
 }
 
@@ -46,7 +48,7 @@ impl Actor for ActorThree {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        self.subscribe_async::<MessageOne>(ctx);
+        self.subscribe_async::<BrokerType, MessageOne>(ctx);
     }
 }
 
@@ -55,7 +57,7 @@ impl Handler<MessageOne> for ActorThree {
 
     fn handle(&mut self, msg: MessageOne, _ctx: &mut Self::Context) {
         println!("ActorThree Received: {:?}", msg);
-        self.issue_async(MessageTwo(1));
+        self.issue_async::<BrokerType, _>(MessageTwo(1));
     }
 }
 

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -2,7 +2,7 @@ use actix::prelude::*;
 
 use std::any::TypeId;
 
-use crate::broker::{RegisteredBroker};
+use crate::broker::{RegisteredBroker, SystemBroker, ArbiterBroker};
 use crate::msgs::*;
 
 /// The `BrokerIssue` provides functions to issue messages to any subscribers.
@@ -28,6 +28,30 @@ where
             .map_err(|_, _, _| ())
             .map(|_, _, _| ())
             .wait(ctx);
+    }
+
+    /// Helper to asynchronously issue to an system broker
+    /// This is the equivalent of `self.issue_async::<SystemBroker, M>(ctx);`
+    fn issue_system_async<M: BrokerMsg>(&self, msg: M) { 
+        self.issue_async::<SystemBroker, M>(msg);
+    }
+
+    /// Helper to synchronously issue to an system broker
+    /// This is the equivalent of `self.issue_sync::<SystemBroker, M>(ctx);`
+    fn issue_system_sync<M: BrokerMsg>(&self, msg: M, ctx: &mut Self::Context) { 
+        self.issue_sync::<SystemBroker, M>(msg, ctx);
+    }
+
+    /// Helper to asynchronously issue to an arbiter-specific broker
+    /// This is the equivalent of `self.issue_async::<ArbiterBroker, M>(ctx);`
+    fn issue_arbiter_async<M: BrokerMsg>(&self, msg: M) { 
+        self.issue_async::<ArbiterBroker, M>(msg);
+    }
+
+    /// Helper to synchronously issue to an arbiter-specific broker
+    /// This is the equivalent of `self.issue_sync::<ArbiterBroker, M>(ctx);`
+    fn issue_arbiter_sync<M: BrokerMsg>(&self, msg: M, ctx: &mut Self::Context) { 
+        self.issue_sync::<ArbiterBroker, M>(msg, ctx);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! # Actix-Broker
 //!
-//! The `actix_broker` crate contains a Broker `SystemService` that keeps track of active
-//! subscriptions to different `Messages`. This Broker service is automatically started
-//! when an actor uses functions from the `BrokerSubscribe` and `BrokerIssue` traits to
-//! either subscribe to or issue a message.
+//! The `actix_broker` crate contains `SystemService` and `ArbiterService` Brokers that 
+//! keep track of active subscriptions to different `Messages`. Broker services are 
+//! automatically started when an actor uses functions from the `BrokerSubscribe` and 
+//! `BrokerIssue` traits to either subscribe to or issue a message.
 //!
 //! ## Example
 //! ```rust,no_run
@@ -12,7 +12,7 @@
 //! # extern crate actix_broker;
 //! use actix::prelude::*;
 //! // Bring both these traits into scope.
-//! use actix_broker::{BrokerSubscribe, BrokerIssue, SystemBroker};
+//! use actix_broker::{BrokerSubscribe, BrokerIssue, SystemBroker, ArbiterBroker};
 //!
 //! // Note: The message must implement 'Clone'
 //! #[derive(Clone, Message)]
@@ -32,14 +32,14 @@
 //!     type Context = Context<Self>;
 //!
 //!     fn started(&mut self,ctx: &mut Self::Context) {
-//!         // Asynchronously subscribe to a message
+//!         // Asynchronously subscribe to a message on the system (global) broker
 //!         self.subscribe_async::<SystemBroker, MessageOne>(ctx);
-//!         // Asynchronously issue a message to any subscribers
+//!         // Asynchronously issue a message to any subscribers on the system (global) broker
 //!         self.issue_async::<SystemBroker, _>(MessageOne);
-//!         // Synchronously subscribe to a message
-//!         self.subscribe_sync::<SystemBroker, MessageTwo>(ctx);
-//!         // Synchronously issue a message to any subscribers
-//!         self.issue_sync::<SystemBroker, _>(MessageTwo, ctx);
+//!         // Synchronously subscribe to a message on the arbiter (local) broker
+//!         self.subscribe_sync::<ArbiterBroker, MessageTwo>(ctx);
+//!         // Synchronously issue a message to any subscribers on the arbiter (local) broker
+//!         self.issue_sync::<ArbiterBroker, _>(MessageTwo, ctx);
 //!     }
 //! }
 //!     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! # extern crate actix_broker;
 //! use actix::prelude::*;
 //! // Bring both these traits into scope.
-//! use actix_broker::{BrokerSubscribe, BrokerIssue};
+//! use actix_broker::{BrokerSubscribe, BrokerIssue, SystemBroker};
 //!
 //! // Note: The message must implement 'Clone'
 //! #[derive(Clone, Message)]
@@ -33,13 +33,13 @@
 //!
 //!     fn started(&mut self,ctx: &mut Self::Context) {
 //!         // Asynchronously subscribe to a message
-//!         self.subscribe_async::<MessageOne>(ctx);
+//!         self.subscribe_async::<SystemBroker, MessageOne>(ctx);
 //!         // Asynchronously issue a message to any subscribers
-//!         self.issue_async(MessageOne);
+//!         self.issue_async::<SystemBroker, _>(MessageOne);
 //!         // Synchronously subscribe to a message
-//!         self.subscribe_sync::<MessageTwo>(ctx);
+//!         self.subscribe_sync::<SystemBroker, MessageTwo>(ctx);
 //!         // Synchronously issue a message to any subscribers
-//!         self.issue_sync(MessageTwo, ctx);
+//!         self.issue_sync::<SystemBroker, _>(MessageTwo, ctx);
 //!     }
 //! }
 //!     
@@ -49,7 +49,7 @@
 //!
 //!     fn handle(&mut self, msg: MessageOne, ctx: &mut Self::Context) {
 //!         // An actor does not have to handle a message to just issue it
-//!         self.issue_async(MessageThree);
+//!         self.issue_async::<SystemBroker, _>(MessageThree);
 //!     }
 //! }
 //!
@@ -69,7 +69,7 @@ mod subscribe;
 
 pub use crate::msgs::BrokerMsg;
 
-pub use crate::broker::Broker;
+pub use crate::broker::{Broker, SystemBroker, ArbiterBroker};
 
 pub use crate::subscribe::BrokerSubscribe;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,13 @@
 //!
 //!     fn started(&mut self,ctx: &mut Self::Context) {
 //!         // Asynchronously subscribe to a message on the system (global) broker
-//!         self.subscribe_async::<SystemBroker, MessageOne>(ctx);
+//!         self.subscribe_system_async::<MessageOne>(ctx);
 //!         // Asynchronously issue a message to any subscribers on the system (global) broker
-//!         self.issue_async::<SystemBroker, _>(MessageOne);
+//!         self.issue_system_async(MessageOne);
 //!         // Synchronously subscribe to a message on the arbiter (local) broker
-//!         self.subscribe_sync::<ArbiterBroker, MessageTwo>(ctx);
+//!         self.subscribe_arbiter_sync::<MessageTwo>(ctx);
 //!         // Synchronously issue a message to any subscribers on the arbiter (local) broker
-//!         self.issue_sync::<ArbiterBroker, _>(MessageTwo, ctx);
+//!         self.issue_arbiter_sync(MessageTwo, ctx);
 //!     }
 //! }
 //!     

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -4,7 +4,7 @@ use actix::prelude::*;
 
 use std::any::TypeId;
 
-use crate::broker::RegisteredBroker;
+use crate::broker::{RegisteredBroker, SystemBroker, ArbiterBroker};
 use crate::msgs::*;
 
 /// The `BrokerSubscribe` trait has functions to register an actor's interest in different
@@ -47,6 +47,46 @@ where
                 }
             })
             .wait(ctx);
+    }
+
+    /// Helper to asynchronously subscribe to a system broker
+    /// This is the equivalent of `self.subscribe_async::<SystemBroker, M>(ctx);`
+    fn subscribe_system_async<M: BrokerMsg>(&self, ctx: &mut Self::Context)
+    where
+        Self: Handler<M>,
+        <Self as Actor>::Context: ToEnvelope<Self, M>,
+    {
+        self.subscribe_async::<SystemBroker, M>(ctx);
+    }
+
+    /// Helper to synchronously subscribe to a system broker
+    /// This is the equivalent of `self.subscribe_sync::<SystemBroker, M>(ctx);
+    fn subscribe_system_sync<M: BrokerMsg>(&self, ctx: &mut Self::Context)
+    where
+        Self: Handler<M>,
+        <Self as Actor>::Context: ToEnvelope<Self, M>,
+    {
+        self.subscribe_sync::<SystemBroker, M>(ctx);
+    }
+
+    /// Helper to asynchronously subscribe to an arbiter-specific broker
+    /// This is the equivalent of `self.subscribe_async::<ArbiterBroker, M>(ctx);`
+    fn subscribe_arbiter_async<M: BrokerMsg>(&self, ctx: &mut Self::Context)
+    where
+        Self: Handler<M>,
+        <Self as Actor>::Context: ToEnvelope<Self, M>,
+    {
+        self.subscribe_async::<ArbiterBroker, M>(ctx);
+    }
+
+    /// Helper to synchronously subscribe to an arbiter-specific broker
+    /// This is the equivalent of `self.subscribe_sync::<ArbiterBroker, M>(ctx);
+    fn subscribe_arbiter_sync<M: BrokerMsg>(&self, ctx: &mut Self::Context)
+    where
+        Self: Handler<M>,
+        <Self as Actor>::Context: ToEnvelope<Self, M>,
+    {
+        self.subscribe_sync::<ArbiterBroker, M>(ctx);
     }
 }
 

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -4,7 +4,7 @@ use actix::prelude::*;
 
 use std::any::TypeId;
 
-use crate::broker::Broker;
+use crate::broker::RegisteredBroker;
 use crate::msgs::*;
 
 /// The `BrokerSubscribe` trait has functions to register an actor's interest in different
@@ -15,12 +15,12 @@ where
     <Self as Actor>::Context: AsyncContext<Self>,
 {
     /// Asynchronously subscribe to a message.
-    fn subscribe_async<M: BrokerMsg>(&self, ctx: &mut Self::Context)
+    fn subscribe_async<T: RegisteredBroker,  M: BrokerMsg>(&self, ctx: &mut Self::Context)
     where
         Self: Handler<M>,
         <Self as Actor>::Context: ToEnvelope<Self, M>,
     {
-        let broker = Broker::from_registry();
+        let broker = T::get_broker();
         let recipient = ctx.address().recipient::<M>();
         broker.do_send(SubscribeAsync(recipient, TypeId::of::<Self>()));
     }
@@ -29,12 +29,12 @@ where
     /// This actor will do nothing else until its interest is registered.
     /// If messages of that type have been sent to the broker previously, a copy of the latest
     /// message is sent to the calling actor after it has subscribed.
-    fn subscribe_sync<M: BrokerMsg>(&self, ctx: &mut Self::Context)
+    fn subscribe_sync<T: RegisteredBroker, M: BrokerMsg>(&self, ctx: &mut Self::Context)
     where
         Self: Handler<M>,
         <Self as Actor>::Context: ToEnvelope<Self, M>,
     {
-        let broker = Broker::from_registry();
+        let broker = T::get_broker();
         let recipient = ctx.address().recipient::<M>();
 
         broker


### PR DESCRIPTION
hey thanks for making a neat thing! 

i'm porting a project to actix and have been trying to work out how to run multiple instances of the same application (the test suite runs a number of interacting instances consisting of a bunch of agents), and i got stuck since this registers a `SystemService` rather than an `ArbiterService`.

since they're both useful cases i though maybe it'd be handy to support both at once (rather than a feature flag or something), so, this PR introduces `SystemBroker` and `ArbiterBroker` marker types that let you select between each broker.

it does make the api a little more complex (and is as such a breaking change), but hopefully that is mitigated via the documentation and additional utility ^_^