### PR TITLE
Improve documentation and remove deprecation warning

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -14,8 +14,8 @@ type TypeMap<A> = HashMap<TypeId, A, BuildHasherDefault<FnvHasher>>;
 
 #[derive(Default)]
 pub struct Broker<T> {
-    sub_map: TypeMap<Vec<(TypeId, Box<Any>)>>,
-    msg_map: TypeMap<Box<Any>>,
+    sub_map: TypeMap<Vec<(TypeId, Box<dyn Any>)>>,
+    msg_map: TypeMap<Box<dyn Any>>,
     _t: PhantomData<T>,
 }
 
@@ -176,7 +176,7 @@ impl Supervised for Broker<SystemBroker> {}
 impl ArbiterService for Broker<ArbiterBroker> {}
 impl Supervised for Broker<ArbiterBroker> {}
 
-pub trait RegisteredBroker: 'static 
+pub trait RegisteredBroker: 'static
 where Self: std::marker::Sized
 {
     fn get_broker() -> Addr<Broker<Self>>;

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -5,7 +5,9 @@ use std::any::TypeId;
 use crate::broker::{RegisteredBroker, SystemBroker, ArbiterBroker};
 use crate::msgs::*;
 
-/// The `BrokerIssue` provides functions to issue messages to any subscribers.
+/// The `BrokerIssue` provides functions to issue messages to subscribers.
+///
+/// This will not deliver the message to the actor that sent it.
 pub trait BrokerIssue
 where
     Self: Actor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
 //! # extern crate actix;
 //! # extern crate actix_broker;
 //! use actix::prelude::*;
-//! // Bring both these traits into scope.
-//! use actix_broker::{BrokerSubscribe, BrokerIssue, SystemBroker, ArbiterBroker};
+//! use actix_broker::{BrokerSubscribe, BrokerIssue, SystemBroker, ArbiterBroker, Broker};
 //!
 //! // Note: The message must implement 'Clone'
 //! #[derive(Clone, Message)]
@@ -53,7 +52,12 @@
 //!     }
 //! }
 //!
-//!     // Handler for MessageTwo...
+//! // Messages can also be sent from outside actors
+//! fn my_function() {
+//!     Broker::<SystemBroker>::issue_async(MessageOne);
+//! }
+//! #
+//! # // Handler for MessageTwo...
 //! # impl Handler<MessageTwo> for ActorOne {
 //! #     type Result = ();
 //!


### PR DESCRIPTION
This:
* Shows that messages can be sent from outside of an actor context in the main example
* Adds a note to `BrokerIssue`  that messages are not delivered to the actor that sends them
* Removes deprecated uses of `Box<Trait>` without `dyn`

I know these changes are unrelated, but they're all very small. Let me know if you want me to break them up.

Fixes https://github.com/chris-ricketts/actix-broker/issues/5