### PR TITLE
Remove default actix deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [".gitignore"]
 edition = "2018"
 
 [dependencies]
-actix = "0.9.0"
+actix = { version = "0.9.0", default-features = false }
 fnv = "1.0.6"
 log = "0.4.5"
 


### PR DESCRIPTION
Removing the unused default actix dependencies reduces the number of
extra dependencies pulled in (e.g. actix-http and trust-dns), which is
useful for projects using actix-broker but don't need the added
dependencies.