### PR TITLE
Revert "Remove default actix deps"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [".gitignore"]
 edition = "2018"
 
 [dependencies]
-actix = { version = "0.9.0", default-features = false }
+actix = "0.9.0"
 fnv = "1.0.6"
 log = "0.4.5"
 


### PR DESCRIPTION
Reverts chris-ricketts/actix-broker#9

I get the following errors when building:
```
   Compiling actix v0.9.0
error[E0432]: unresolved import `tokio::io::AsyncWriteExt`
  --> /home/chris/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-0.9.0/src/io.rs:12:29
   |
12 | use tokio::io::{AsyncWrite, AsyncWriteExt};
   |                             ^^^^^^^^^^^^^
   |                             |
   |                             no `AsyncWriteExt` in `io`
   |                             help: a similar name exists in the module: `AsyncWrite`

error[E0599]: no method named `write` found for struct `std::cell::RefMut<'_, T>` in the current scope
   --> /home/chris/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-0.9.0/src/io.rs:418:34
    |
418 |             let _ = async_writer.write(&inner.buffer);
    |                                  ^^^^^ method not found in `std::cell::RefMut<'_, T>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `write`, perhaps you need to implement one of them:
            candidate #1: `std::io::Write`
            candidate #2: `std::hash::Hasher`
            candidate #3: `futures_util::io::AsyncWriteExt`

error[E0599]: no method named `flush` found for struct `std::cell::RefMut<'_, T>` in the current scope
   --> /home/chris/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-0.9.0/src/io.rs:419:34
    |
419 |             let _ = async_writer.flush();
    |                                  ^^^^^ method not found in `std::cell::RefMut<'_, T>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `flush`, perhaps you need to implement one of them:
            candidate #1: `std::io::Write`
            candidate #2: `futures_util::sink::SinkExt`
            candidate #3: `futures_util::io::AsyncWriteExt`
            candidate #4: `log::Log`

error: aborting due to 3 previous errors
```
Building with rustc 1.44.1